### PR TITLE
Fix launch error on ROS 2 humble

### DIFF
--- a/ldlidar_node/launch/ldlidar.launch.py
+++ b/ldlidar_node/launch/ldlidar.launch.py
@@ -33,10 +33,11 @@ def generate_launch_description():
     )
 
     # LDLidar lifecycle node
-    ldlidar_node = LifecycleNode(        
+    ldlidar_node = LifecycleNode(
         package = 'ldlidar_node',
         executable = 'ldlidar_node',
         name = node_name,
+        namespace='',
         output='screen',
         parameters=[
             # YAML files
@@ -76,4 +77,4 @@ def generate_launch_description():
     ld.add_action(ldlidar_node)
 
     return ld
-    
+ 


### PR DESCRIPTION
This pull request fixes the following error on ROS 2 humble

reference: https://github.com/ros2/demos/pull/456

```
$ ros2 launch ldlidar_node ldlidar.launch.py 
[INFO] [launch]: All log files can be found below /home/ubuntu/.ros/log/2022-11-27-18-01-39-926185-i59600k-499
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught exception when trying to load file of format [py]: LifecycleNode.__init__() missing 1 required keyword-only argument: 'namespace'
```