### PR TITLE
Added rclcpp::Rate to lidarThreadFunc to reduce CPU load

### DIFF
--- a/ldlidar_component/component/src/ldlidar_component.cpp
+++ b/ldlidar_component/component/src/ldlidar_component.cpp
@@ -551,6 +551,8 @@ void LdLidarComponent::lidarThreadFunc()
   ldlidar::Points2D laser_scan_points;
   double lidar_scan_freq;
 
+  rclcpp::Rate rate(20.0);
+
   while (1) {
     // ----> Interruption check
     if (!rclcpp::ok()) {
@@ -584,6 +586,8 @@ void LdLidarComponent::lidarThreadFunc()
     } else {
       _publishing = false;
     }
+
+    rate.sleep();
   }
 
   RCLCPP_DEBUG(get_logger(), "Lidar thread finished");

--- a/ldlidar_component/ldlidar_driver/src/logger/log_module.cpp
+++ b/ldlidar_component/ldlidar_driver/src/logger/log_module.cpp
@@ -25,6 +25,7 @@
 #pragma comment(lib, "comsuppw.lib")
 #else
 #include <stdlib.h>
+#include <pthread.h>
 #endif
 
 //使用vswprintf会出现奔溃的情况如果，传入数据大于 VA_PARAMETER_MAX 就会出现崩溃


### PR DESCRIPTION
The lidarThreadFunc did active waiting for scans to be available which led to high cpu usage and powerdraw on battery powered devices.

The pthread.h include in "ldlidar_component/ldlidar_driver/src/logger/log_module.cpp" was necessary to compile the project.