### PR TITLE
feat: add baudrate parametrization for STL-27L support

### DIFF
--- a/ldlidar_component/component/src/ldlidar_component.cpp
+++ b/ldlidar_component/component/src/ldlidar_component.cpp
@@ -101,11 +101,16 @@ void LdLidarComponent::getCommParams()
   getParam(
     "comm.serial_port", _serialPort, _serialPort, "Communication serial port path", true,
     " * Serial port: ");
-
+  
   getParam(
+    "comm.baudrate", _baudrate, _baudrate, "Serial baudrate", false,
+    " * Baudrate: ");
+  
+      getParam(
     "comm.timeout_msec", _readTimeOut_msec, _readTimeOut_msec, "Data reading timeout in msec",
     false, " * Timeout [msec]: ");
-  // <---- Communication
+  
+    // <---- Communication
 }
 
 void LdLidarComponent::getLidarParams()

--- a/ldlidar_component/component/src/ldlidar_component.cpp
+++ b/ldlidar_component/component/src/ldlidar_component.cpp
@@ -105,8 +105,7 @@ void LdLidarComponent::getCommParams()
   getParam(
     "comm.baudrate", _baudrate, _baudrate, "Serial baudrate", false,
     " * Baudrate: ");
-  
-      getParam(
+  getParam(
     "comm.timeout_msec", _readTimeOut_msec, _readTimeOut_msec, "Data reading timeout in msec",
     false, " * Timeout [msec]: ");
   

--- a/ldlidar_node/params/ldlidar.yaml
+++ b/ldlidar_node/params/ldlidar.yaml
@@ -9,7 +9,7 @@
 
     comm:
       serial_port: '/dev/ldlidar' # serial port name
-      baudrate: 230400 # serial baudrate
+      baudrate: 230400 # serial baudrate for LDLiDAR_LD19: 230400. Serial baudrate for LDLiDAR_STL27L: 921600
       timeout_msec: 1000 # data communication timeout in msec
 
     lidar:


### PR DESCRIPTION
## Description
Adds baudrate as a configurable parameter in `ldlidar.yaml` to support STL-27L (921600 baud) while maintaining compatibility with LD19/LD06 (230400 baud).

## Changes
- Added `baudrate` parameter in `config/ldlidar.yaml` (default: `230400`).
- Modified `getCommParams()` in `src/ldlidar_component.cpp` to read the YAML value.

## Testing
- Verified with:
  - STL-27L (921600 baud) → Success.
  - LD19 (230400 baud) → Success.

## Credits
Thanks to @PetervdPerk-NXP for identifying the issue